### PR TITLE
Add broker skew and cluster list routes

### DIFF
--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -62,7 +62,7 @@ class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: Ka
     }
   }
 
-  def brokersSkewPercentage(c: String, t:String) = Action.async { implicit request =>
+  def brokersSkewPercentage(c: String, t: String) = Action.async { implicit request =>
     kafkaManager.getTopicIdentity(c, t).map { errorOrTopicIdentity =>
       errorOrTopicIdentity.fold(
         error => BadRequest(Json.obj("msg" -> error.msg)),

--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -37,7 +37,7 @@ class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: Ka
     kafkaManager.getTopicList(c).map { errorOrTopicList =>
       errorOrTopicList.fold(
         error => BadRequest(Json.obj("msg" -> error.msg)),
-        topicList => Ok(Json.obj("topics" -> topicList.list))
+        topicList => Ok(Json.obj("topics" -> topicList.list.sorted))
       )
     }
   }

--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -1,7 +1,7 @@
 /**
-  * Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
-  * See accompanying LICENSE file.
-  */
+ * Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
+ * See accompanying LICENSE file.
+ */
 
 package controllers.api
 

--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -46,25 +46,21 @@ class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: Ka
     kafkaManager.getClusterList.map { errorOrClusterList =>
       errorOrClusterList.fold(
         error => BadRequest(Json.obj("msg" -> error.msg)),
-        //                clusterList => Ok(Json.obj("clusters" -> (clusterList.active.map(cc => Map("name" -> cc.name, "status" -> "active")) ++
-        //                  clusterList.pending.map(cc => Map("name" -> cc.name, "status" -> "pending"))).sortBy(_("name"))))
-        clusterList => Ok(makeJson(clusterList, status))
+        clusterList => Ok(getClusterListJson(clusterList, status))
       )
     }
   }
 
-  def makeJson(clusterList: KMClusterList, status: Option[String]) = {
+  def getClusterListJson(clusterList: KMClusterList, status: Option[String]) = {
     val active = clusterList.active.map(cc => Map("name" -> cc.name, "status" -> "active"))
     val pending = clusterList.pending.map(cc => Map("name" -> cc.name, "status" -> "pending"))
 
-    if (status.isEmpty) {
-      Json.obj("clusters" -> (active ++ pending).sortBy(_("name")))
-    } else if (status.get == "active") {
+    if (status.getOrElse(None) == "active") {
       Json.obj("clusters" -> active.sortBy(_("name")))
-    } else if (status.get == "pending") {
+    } else if (status.getOrElse(None) == "pending") {
       Json.obj("clusters" -> pending.sortBy(_("name")))
     } else {
-      Json.obj("option" -> status)
+      Json.obj("clusters" -> (active ++ pending).sortBy(_("name")))
     }
   }
 

--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -55,12 +55,10 @@ class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: Ka
     val active = clusterList.active.map(cc => Map("name" -> cc.name, "status" -> "active"))
     val pending = clusterList.pending.map(cc => Map("name" -> cc.name, "status" -> "pending"))
 
-    if (status.getOrElse(None) == "active") {
-      Json.obj("clusters" -> active.sortBy(_("name")))
-    } else if (status.getOrElse(None) == "pending") {
-      Json.obj("clusters" -> pending.sortBy(_("name")))
-    } else {
-      Json.obj("clusters" -> (active ++ pending).sortBy(_("name")))
+    status match {
+      case Some("active") => Json.obj("clusters" -> active.sortBy(_("name")))
+      case Some("pending") => Json.obj("clusters" -> pending.sortBy(_("name")))
+      case _ => Json.obj("clusters" -> (active ++ pending).sortBy(_("name")))
     }
   }
 

--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -1,20 +1,21 @@
 /**
- * Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
- * See accompanying LICENSE file.
- */
+  * Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
+  * See accompanying LICENSE file.
+  */
 
 package controllers.api
 
 import controllers.KafkaManagerContext
 import features.ApplicationFeatures
+import kafka.manager.model.ActorModel.KMClusterList
 import models.navigation.Menus
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json._
 import play.api.mvc._
 
 /**
- * @author jisookim0513
- */
+  * @author jisookim0513
+  */
 
 class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManagerContext)
                       (implicit af: ApplicationFeatures, menus: Menus) extends Controller with I18nSupport {
@@ -36,7 +37,42 @@ class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: Ka
     kafkaManager.getTopicList(c).map { errorOrTopicList =>
       errorOrTopicList.fold(
         error => BadRequest(Json.obj("msg" -> error.msg)),
-        topicList => Ok(Json.obj("topics" -> topicList.list.sorted))
+        topicList => Ok(Json.obj("topics" -> topicList.list))
+      )
+    }
+  }
+
+  def clusters(status: Option[String]) = Action.async { implicit request =>
+    kafkaManager.getClusterList.map { errorOrClusterList =>
+      errorOrClusterList.fold(
+        error => BadRequest(Json.obj("msg" -> error.msg)),
+        //                clusterList => Ok(Json.obj("clusters" -> (clusterList.active.map(cc => Map("name" -> cc.name, "status" -> "active")) ++
+        //                  clusterList.pending.map(cc => Map("name" -> cc.name, "status" -> "pending"))).sortBy(_("name"))))
+        clusterList => Ok(makeJson(clusterList, status))
+      )
+    }
+  }
+
+  def makeJson(clusterList: KMClusterList, status: Option[String]) = {
+    val active = clusterList.active.map(cc => Map("name" -> cc.name, "status" -> "active"))
+    val pending = clusterList.pending.map(cc => Map("name" -> cc.name, "status" -> "pending"))
+
+    if (status.isEmpty) {
+      Json.obj("clusters" -> (active ++ pending).sortBy(_("name")))
+    } else if (status.get == "active") {
+      Json.obj("clusters" -> active.sortBy(_("name")))
+    } else if (status.get == "pending") {
+      Json.obj("clusters" -> pending.sortBy(_("name")))
+    } else {
+      Json.obj("option" -> status)
+    }
+  }
+
+  def brokersSkewPercentage(c: String, t:String) = Action.async { implicit request =>
+    kafkaManager.getTopicIdentity(c, t).map { errorOrTopicIdentity =>
+      errorOrTopicIdentity.fold(
+        error => BadRequest(Json.obj("msg" -> error.msg)),
+        topicIdentity => Ok(Json.obj("topic" -> t, "brokersSkewPercentage" -> topicIdentity.brokersSkewPercentage))
       )
     }
   }

--- a/app/controllers/api/KafkaStateCheck.scala
+++ b/app/controllers/api/KafkaStateCheck.scala
@@ -14,8 +14,8 @@ import play.api.libs.json._
 import play.api.mvc._
 
 /**
-  * @author jisookim0513
-  */
+ * @author jisookim0513
+ */
 
 class KafkaStateCheck (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManagerContext)
                       (implicit af: ApplicationFeatures, menus: Menus) extends Controller with I18nSupport {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -20,7 +20,7 @@ play.http.requestHandler = "play.http.DefaultHttpRequestHandler"
 play.http.context = "/"
 play.application.loader=loader.KafkaManagerLoader
 
-kafka-manager.zkhosts="kafka-manager-zookeeper:2181"
+kafka-manager.zkhosts="localhost:2181"
 kafka-manager.zkhosts=${?ZK_HOSTS}
 pinned-dispatcher.type="PinnedDispatcher"
 pinned-dispatcher.executor="thread-pool-executor"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -20,7 +20,7 @@ play.http.requestHandler = "play.http.DefaultHttpRequestHandler"
 play.http.context = "/"
 play.application.loader=loader.KafkaManagerLoader
 
-kafka-manager.zkhosts="localhost:2181"
+kafka-manager.zkhosts="kafka-manager-zookeeper:2181"
 kafka-manager.zkhosts=${?ZK_HOSTS}
 pinned-dispatcher.type="PinnedDispatcher"
 pinned-dispatcher.executor="thread-pool-executor"

--- a/conf/routes
+++ b/conf/routes
@@ -54,6 +54,8 @@ POST        /clusters/:c/logkafkas/:h/:l/disableConfig    controllers.Logkafka.h
 POST        /clusters/:c/logkafkas/:h/:l/enableConfig     controllers.Logkafka.handleEnableConfig(c:String, h:String, l:String)
 GET         /api/status/:c/brokers                        controllers.api.KafkaStateCheck.brokers(c:String)
 GET         /api/status/:c/topics                         controllers.api.KafkaStateCheck.topics(c:String)
+GET         /api/status/clusters                          controllers.api.KafkaStateCheck.clusters(status:Option[String])
+GET         /api/status/:c/:t/brokersSkewPercentage       controllers.api.KafkaStateCheck.brokersSkewPercentage(c:String, t:String)
 GET         /api/status/:c/:t/underReplicatedPartitions   controllers.api.KafkaStateCheck.underReplicatedPartitions(c:String,t:String)
 GET         /api/status/:c/:t/unavailablePartitions       controllers.api.KafkaStateCheck.unavailablePartitions(c:String,t:String)
 


### PR DESCRIPTION
Added routes to conf/routes to get back the broker skew for a given cluster and topic in a JSON and a list of clusters (represented by dictionaries) in a JSON. Added methods to KafkaStateCheck controller attached to the routes. 